### PR TITLE
Add dedicated Nexus ID specification

### DIFF
--- a/coap_format_spec.md
+++ b/coap_format_spec.md
@@ -136,6 +136,7 @@ No IP networking or internet access is assumed or implied for any devices.
 Instead, Nexus Channel Core CoAP messages are exchanged over lower-level links
 including but not limited to:
 
+* OpenPAYGOLink
 * Bluetooth Low Energy (BLE 5.0)
 * I2C
 * UART

--- a/coap_format_spec.md
+++ b/coap_format_spec.md
@@ -132,7 +132,7 @@ transmitted packet to fit within 128 bytes after adding header and footer data).
 
 ## Link Layer: Device Addressing
 
-No IP networking or internet access or assumed or implied for any devices.
+No IP networking or internet access is assumed or implied for any devices.
 Instead, Nexus Channel Core CoAP messages are exchanged over lower-level links
 including but not limited to:
 
@@ -145,44 +145,8 @@ including but not limited to:
 
 The COAP header and CBOR payload contain no address information, however,
 every Nexus Channel Core device has a "Nexus ID". This Nexus ID is a 6-byte
-identifier which is globally unique. It consists of two parts:
-
-* 4-byte 'device ID' unique for all IDs assigned from a given 'authority'
-* 2-byte 'authority ID' indicating what party assigned the device ID
-
-Every time a Nexus Channel Core message is sent or received between nodes,
-the source and destination Nexus ID addresses are included. This is done by
-middleware code that sits between the resource models and the link layer,
-which is aware of the devices "Nexus ID", and adds this information before
-passing the CoAP packet to the link layer. In many cases, this may be as
-simple as hard-coding a constant (known at factory production time) in the
-link layer as the 'Nexus ID source address' of the device, and letting
-the application code 'fill in' a static 6-byte field with the destination
-address.
-
-The Nexus ID addresses might not be visible on the wire, as the link-layer
-may abbreviate or elide them as long as they can be reconstructed in full by
-the receiver's link layer before passing the message upward to the Nexus
-Channel Core layer.
-
-It is assumed that the lower-level links have a way to 'map' Nexus Channel Core
-"Addresses" (6-byte Nexus IDs) to lower-level link node addresses if not
-sending the full 6-byte source and destination addresses directly on
-the wire. The details of this address bridging is not described in this
-specification.
-
-## Link Layer: Multicasting
-
-Nexus Channel Core assumes that multicasting is possible, that is, that any
-device may send a 'broadcast' that is received by all other devices on the
-local network.
-
-This broadcast may elicit zero or one responses from connected devices (implying
-that this broadcast contains content that is understood by one specific
-device).
-
-A link layer *may* support broadcasting with responses from all recipients,
-which can speed up resource discovery, but is not strictly required.
+identifier which is globally unique and that supports multicast and limited-scope
+(such as link-local) address assignment. Read more [here](TODO).
 
 ## Reference Implementation
 

--- a/coap_format_spec.md
+++ b/coap_format_spec.md
@@ -147,7 +147,7 @@ including but not limited to:
 The COAP header and CBOR payload contain no address information, however,
 every Nexus Channel Core device has a "Nexus ID". This Nexus ID is a 6-byte
 identifier which is globally unique and that supports multicast and limited-scope
-(such as link-local) address assignment. Read more [here](TODO).
+(such as link-local) address assignment. Read more [here](nexus_id_spec.md).
 
 ## Reference Implementation
 

--- a/nexus_id_spec.md
+++ b/nexus_id_spec.md
@@ -1,0 +1,147 @@
+# Nexus Channel Core - Nexus ID Specification
+
+Version: 0.9.0
+
+## Purpose and Background
+
+The Nexus ID is a globally-unique identifier that is *required* to be stored
+by all devices that implement Nexus Channel Core. It solves many challenges
+facing manufacturers of interoperable devices that may need to be managed by
+external software platforms.
+
+## Structure
+
+The Nexus ID is a 6-byte structure that consists of two parts:
+
+```
+ <-2 bytes-> <----4 bytes---->
++-----------+-----------------+
+| Authority |    Device ID    |
+| ID        |                 |
++-----------+-----------------+
+```
+
+* 2-byte 'Authority ID' indicating what party assigned the device ID
+* 4-byte 'Device ID' unique for all IDs assigned from a given authority
+
+Manufacturers are assigned a unique Authority ID by the maintainer of Nexus
+(currently Angaza). Manufacturers can then serialize a practically infinite
+number of Device IDs according to their own practices and preferences. 
+
+As long as all manufacturers guarantee that they are using their own Authority 
+ID and that there are no collisions within their own Device ID space, then there 
+cannot be any identity collisions between devices communicating on the same Nexus
+Channel Core network.
+
+## External vs. Internal Identifiers
+
+Many device management software platforms require a device-specific identifier
+to reference value-added services related to that device. For example, Angaza 
+uses a device's identifier to reference its related PAYG loan account.
+
+The Device ID part of the Nexus ID *can* be used as an external identifier for
+these purposes, if a manufacturer wishes to reduce the number of serialization
+schemes in use. However, it is not required that the Nexus ID is exposed
+externally. It must just be assigned and stored internally in the device
+firmware (and accessed through Nexus Channel Core APIs) to avoid addressing 
+collisions between devices on a Nexus Channel Core network.
+
+## Link Layer: Assumptions and Flexibility
+
+Nexus Channel Core operates on the application layer and is designed to work with
+a wide range of link layers. The structure of the Nexus ID is intentionally
+designed to make this link-layer flexibility possible.
+
+Nexus Channel Core makes only a few assumptions about the Nexus ID and the link
+layer:
+
+* Nexus Channel Core specifies the destination Nexus ID for each request to the
+link layer to send a message
+* Nexus Channel Core requires the link layer to provide the source and
+destination Nexus ID of a received message
+* Link layer should have the capability to send a message to every device in
+the network (broadcast) and to receive a reply (Nexus Channel Core does not do any
+bridging; all nodes in the network must be addressable by the link layer)
+
+Nexus Channel Core doesn't care how the above are met. This makes it easy for highly-
+constrained networks to meet the requirements.
+
+### Transmitting Nexus IDs in Highly-Constrained Networks
+
+For networks containing highly bandwidth-constrained buses, the link layer may
+abbreviate or elide the source and destination Nexus IDs. Therefore, the Nexus IDs
+may not be visible on the wire. This is permissible as long as they can be
+reconstructed in full by the receiver's link layer before passing the message upward
+to the Nexus Channel Core layer.
+
+In this scenario, is assumed that the lower-level links have a way to map Nexus Channel
+Core "addresses" (6-byte Nexus IDs) to lower-level link node addresses if not
+sending the full 6-byte source and destination addresses directly on the wire. The 
+details of such an address bridging scheme is not described in this specification.
+
+For networks containing highly memory-constrained devices, middleware may hard-code
+a constant (known at factory production time) in the link layer as the Nexus ID source
+address of the device (for outbound messages) and allocate a static 6-byte field
+for the source address (for inbound messages).
+
+## Special Authority ID Values
+
+As specified in the last section, Nexus Channel Core requires that the link layer
+is able to broadcast a message, or send it to every other device on the local
+network. This is indicated by a special Authority ID in the Nexus ID that is reserved
+to make this requirement and other common manufacturing use cases easy to support.
+
+The reserved Authority IDs are:
+
+* **0xFFFF**: reserved for development/testing (anyone can use or make IDs in this
+space in a pre-production/testing context)
+* **0x0000-0x00FF**: reserved for core 'GOGLA-related' use cases currently, including a
+'globally unique' PAYG ID scheme
+* **0xFE80**: reserved for dynamically-assigned Nexus IDs (e.g. Nexus IDs that aren't
+globally-unique, e.g. if the link layer has a scheme where it dynamically assigns
+identities to devices that have no factory assigned ID or outside world mapping to those
+device IDs)
+* **0xFFxx (except 0xFFFF)**: reserved to indicate that this message should be broadcast
+to all devices in the local network. As such, it will only be used as a destination
+address. The lower byte is variable 'xx' so that in the future it is possible to add scope
+context to the broadcast. However, it is expected that in most cases, the link layer will
+not support broadcast scopes and ignore the lower byte (the API also includes a 'broadcast'
+flag so the destination address can be completely ignored by the link layer in that case
+as well). This broadcast may elicit zero or one responses from connected devices, implying
+that the broadcast contains content that is understood by one specific device. A link layer
+*may* support broadcasting with responses from all recipients, which can speed up resource
+discovery, but this is not required.
+
+### IPV6 Semantics
+
+The special Authority ID values 0xFE80 and 0xFFxx were chosen to correspond to published
+IPV6 standards. `0xFE80` is the [link-local unicast address](https://tools.ietf.org/html/rfc4291#section-2.4).
+`0xFFxx` includes the "variable-scope" multicast addresses that are currently
+[registered with the IANA](https://www.iana.org/assignments/ipv6-multicast-addresses/ipv6-multicast-addresses.xhtml#variable).
+
+Examples:
+
+* `{0x0000, 0x12345678} // globally-unique GOGLA identifiers; globally-unique Nexus ID`
+* `{0xFE80, 0x00000010} // dynamically-assigned by link layer, valid only in the local system and not globally-unique`
+
+## Internet Addressing and IPV6 Expansion
+
+For devices that are exposed to the Internet, Nexus ID can be expanded to a valid IPV6
+address. The size of the Nexus ID as 48 bits was selected to allow conversion of the Nexus ID into
+a valid IPV6 address using EUI-64 expansion (same as MAC address expansion, described 
+in [RFC 2373](https://tools.ietf.org/html/rfc2373#page-19)).
+
+There is also a granted ARIN CIDR block of IPV6 address space for devices that comply to the
+Nexus Channel Core specification, which means that any Nexus Channel Core device with a factory assigned,
+fixed ID is guaranteed to also have a globally unique, completely valid IPV6 address.
+
+This is accomplished by running an EUI-64 conversion on the Nexus ID to get the lower 64 bits
+of an IPV6 address, and then getting the (fixed) upper 64-bits from the ARIN assigned "Nexus"
+CIDR block (the CIDR block can be viewed by running `whois 2620:89:6000:0:0:0:0:0`). The device
+can then be addressed from the Internet, if connected.
+
+## Reference Implementation
+
+The [nexus-embedded](https://github.com/angaza/nexus-embedded/tree/master/nexus)
+implementation meets the above specifications, and assumes a compliant
+underlying link layer is present.

--- a/nexus_id_spec.md
+++ b/nexus_id_spec.md
@@ -21,17 +21,23 @@ The Nexus ID is a 6-byte structure that consists of two parts:
 +-----------+-----------------+
 ```
 
-* 2-byte 'Authority ID' indicating what party assigned the device ID
+* 2-byte 'Authority ID' indicating what party assigned the Device ID
 * 4-byte 'Device ID' unique for all IDs assigned from a given authority
 
-Manufacturers are assigned a unique Authority ID by the maintainer of Nexus
-(currently Angaza). Manufacturers can then serialize a practically infinite
-number of Device IDs according to their own practices and preferences. 
+Authority IDs are assigned by an administrator of Nexus IDs (currently only Angaza,
+but in the future this could be an industry-wide organization like GOGLA). Authority
+IDs function to define unique address spaces. For example, the special Authority ID
+`0x0000` is reserved for PAYG IDs, that is, IDs that are meant to be used for devices
+registered on PAYG software platforms.
 
-As long as all manufacturers guarantee that they are using their own Authority 
-ID and that there are no collisions within their own Device ID space, then there 
-cannot be any identity collisions between devices communicating on the same Nexus
-Channel Core network.
+To a manufacturer of a PAYG device, it is possible, then, to request a single Nexus ID
+in this Authority ID space for use as an internal serial number, a PAYG ID, and an ID
+usable for inter-device communication with Nexus Channel Core!
+
+Because Device IDs within a given Authority ID are administered by a central authority
+and globally unique, as long as participating manufacturers guarantee that there are no
+collisions within their own assigned Device ID space, then there cannot be any identity
+collisions between devices using Nexus IDs.
 
 ## External vs. Internal Identifiers
 
@@ -39,12 +45,12 @@ Many device management software platforms require a device-specific identifier
 to reference value-added services related to that device. For example, Angaza 
 uses a device's identifier to reference its related PAYG loan account.
 
-The Device ID part of the Nexus ID *can* be used as an external identifier for
-these purposes, if a manufacturer wishes to reduce the number of serialization
-schemes in use. However, it is not required that the Nexus ID is exposed
-externally. It must just be assigned and stored internally in the device
-firmware (and accessed through Nexus Channel Core APIs) to avoid addressing 
-collisions between devices on a Nexus Channel Core network.
+As described in the previous section, the Device ID part of the Nexus ID *can*
+be used as an external identifier for these purposes, if a manufacturer wishes to
+reduce the number of serialization schemes in use. However, it is not required that
+the Nexus ID is exposed externally. It must just be assigned and stored internally
+in the device firmware to avoid addressing collisions between devices on a Nexus
+Channel Core network.
 
 ## Link Layer: Assumptions and Flexibility
 
@@ -84,6 +90,18 @@ a constant (known at factory production time) in the link layer as the Nexus ID 
 address of the device (for outbound messages) and allocate a static 6-byte field
 for the source address (for inbound messages).
 
+### Protocol Bridging
+
+Because the Nexus ID is globally unique, it can be bridged to other protocols, again,
+as long as the Nexus ID can be fully reconstructed. For example, for devices that are exposed
+to the Internet, the Nexus ID can be expanded to a valid IPV6 address. The size of the Nexus
+ID as 48 bits was selected to allow conversion of the Nexus ID into a valid IPV6 address using
+EUI-64 expansion (same as MAC address expansion, described in [RFC 2373](https://tools.ietf.org/html/rfc2373#page-19)).
+
+This can be accomplished by running an EUI-64 conversion on the Nexus ID to get the lower 64 bits
+of an IPV6 address, and then getting the (fixed) upper 64-bits by registering with an IPV6
+administrator, such as ARIN.
+
 ## Special Authority ID Values
 
 As specified in the last section, Nexus Channel Core requires that the link layer
@@ -96,7 +114,7 @@ The reserved Authority IDs are:
 * **0xFFFF**: reserved for development/testing (anyone can use or make IDs in this
 space in a pre-production/testing context)
 * **0x0000-0x00FF**: reserved for core 'GOGLA-related' use cases currently, including a
-'globally unique' PAYG ID scheme
+globally-unique PAYG ID scheme (`0x0000`)
 * **0xFE80**: reserved for dynamically-assigned Nexus IDs (e.g. Nexus IDs that aren't
 globally-unique, e.g. if the link layer has a scheme where it dynamically assigns
 identities to devices that have no factory assigned ID or outside world mapping to those
@@ -121,24 +139,8 @@ IPV6 standards. `0xFE80` is the [link-local unicast address](https://tools.ietf.
 
 Examples:
 
-* `{0x0000, 0x12345678} // globally-unique GOGLA identifiers; globally-unique Nexus ID`
+* `{0x0000, 0x12345678} // globally-unique PAYG ID; globally-unique Nexus ID`
 * `{0xFE80, 0x00000010} // dynamically-assigned by link layer, valid only in the local system and not globally-unique`
-
-## Internet Addressing and IPV6 Expansion
-
-For devices that are exposed to the Internet, Nexus ID can be expanded to a valid IPV6
-address. The size of the Nexus ID as 48 bits was selected to allow conversion of the Nexus ID into
-a valid IPV6 address using EUI-64 expansion (same as MAC address expansion, described 
-in [RFC 2373](https://tools.ietf.org/html/rfc2373#page-19)).
-
-There is also a granted ARIN CIDR block of IPV6 address space for devices that comply to the
-Nexus Channel Core specification, which means that any Nexus Channel Core device with a factory assigned,
-fixed ID is guaranteed to also have a globally unique, completely valid IPV6 address.
-
-This is accomplished by running an EUI-64 conversion on the Nexus ID to get the lower 64 bits
-of an IPV6 address, and then getting the (fixed) upper 64-bits from the ARIN assigned "Nexus"
-CIDR block (the CIDR block can be viewed by running `whois 2620:89:6000:0:0:0:0:0`). The device
-can then be addressed from the Internet, if connected.
 
 ## Reference Implementation
 

--- a/resource_type_spec.md
+++ b/resource_type_spec.md
@@ -11,7 +11,7 @@ resource models.
 This document also outlines the structure and format of resource type
 definitions.
 
-From a developers perspective, this document provides the information required
+From a developer's perspective, this document provides the information required
 to implement (or select) a CBOR serializer or deserializer, as well as
 design a Nexus Channel Core resource type/model that will be understood by
 other devices.
@@ -193,7 +193,7 @@ to the special URI `nx/res`, which must elicit a response with an array, one
 element for each resource hosted by the device. Each element in the array
 is a map containing the following keys:
 
-* `rte` - Integer value representing a 'resource type'
+* `rtr` - Integer value representing a 'resource type'
 * `href` - Text string indicating the URI where this resource is accessed
 
 Each resource entry in the array *may* also contain:


### PR DESCRIPTION
@jjmilburn FYI, I've moved the Nexus ID bits from the CoAP spec into a new Nexus ID spec that's targeted at link layer-focused audiences. I borrowed from some of your previous writings and attempted to address all the main questions we've received about it thus far that I can think of.