### PR TITLE
fix: Change `mv` tag to `vb` in documentation

### DIFF
--- a/resource_types/core/101-battery/battery.oas.yaml
+++ b/resource_types/core/101-battery/battery.oas.yaml
@@ -2,7 +2,7 @@
 swagger: '2.0'
 info:
   title: Battery
-  version: 0.7.0
+  version: 0.7.1
   license:
     name: Angaza Data Model License (MIT License)
     url: https://github.com/angaza/nexus-embedded/blob/master/LICENSE
@@ -27,7 +27,8 @@ paths:
         full Nexus Channel security) to update the battery 'low state of charge'
         threshold, if available.
 
-        The minimum set of properties to implement are `cp` and `mv`.
+        The minimum set of properties to implement are `cp` (charge percentage)
+        and `vb` (battery voltage).
 
         Example `GET` response body in CBOR:
           `BF627662192D73626370183262746814626361197D00626473F5626367F5626C62F5626674F462737304FF`


### PR DESCRIPTION
The property representing battery voltage is named to indicate the
physical characteristic its representing ('voltage'), rather than named
by its units ('mv').